### PR TITLE
feat: add 'Open in Editor' button for single image uploads

### DIFF
--- a/src/components/upload/upload-modal.tsx
+++ b/src/components/upload/upload-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {useRouter} from "next/navigation";
-import {useState} from "react";
+import {useState, useEffect} from "react";
 
 import {
   AlertCircle,
@@ -42,6 +42,12 @@ const UploadModal = ({
 }: UploadModalProps) => {
   const router = useRouter();
   const [isNavigating, setIsNavigating] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setIsNavigating(false);
+    }
+  }, [open]);
   const {
     files,
     addFiles,

--- a/src/components/upload/upload-modal.tsx
+++ b/src/components/upload/upload-modal.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import {useRouter} from "next/navigation";
+import {useState} from "react";
+
 import {
   AlertCircle,
   CheckCircle,
   Link2,
+  Loader2,
   RotateCcw,
   Upload,
   X,
@@ -36,6 +40,8 @@ const UploadModal = ({
   onOpenChange,
   uploadOptions = {},
 }: UploadModalProps) => {
+  const router = useRouter();
+  const [isNavigating, setIsNavigating] = useState(false);
   const {
     files,
     addFiles,
@@ -201,6 +207,30 @@ const UploadModal = ({
                       </Button>
                     </div>
                   )}
+
+                  {uploadFile.status === "success" &&
+                    uploadFile.mediaRecord &&
+                    files.length === 1 &&
+                    uploadFile.file.type.includes("image") && (
+                      <Button
+                        onClick={() => {
+                          setIsNavigating(true);
+                          onOpenChange(false);
+                          router.push(`/studio/${uploadFile.mediaRecord?.id}`);
+                        }}
+                        disabled={isNavigating}
+                        className="w-full bg-gradient-to-bl from-blue-400 to-blue-600"
+                      >
+                        {isNavigating ? (
+                          <>
+                            <Loader2 className="mr-2 size-4 animate-spin" />
+                            Opening...
+                          </>
+                        ) : (
+                          "Open in Editor"
+                        )}
+                      </Button>
+                    )}
                 </div>
               ))}
             </div>

--- a/src/hooks/use-imagekit-upload.ts
+++ b/src/hooks/use-imagekit-upload.ts
@@ -192,7 +192,12 @@ export const useImageKitUpload = () => {
           )
         );
 
-        await saveToDatabase(fileData, uploadResponse);
+        const mediaRecord = await saveToDatabase(fileData, uploadResponse);
+
+        // Update with media record
+        setFiles(prev =>
+          prev.map(f => (f.id === fileData.id ? {...f, mediaRecord} : f))
+        );
 
         return uploadResponse;
       } catch (error) {


### PR DESCRIPTION
- Add navigation to studio editor after successful image upload
- Show 'Open in Editor' button only for single image uploads
- Store media record reference in upload file state
- Integrate with Next.js router for seamless navigation
- Enhance user workflow by providing direct access to image editing